### PR TITLE
hacky fix - override bootstrap defaults for text color rule

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,5 +10,3 @@
 // Your CSS partials
 @import "components/index";
 @import "pages/index";
-@import "pages/home";
-@import "pages/location"

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -3,15 +3,15 @@ h2 {
 }
 
 .form-text {
-  color:#C69749;
+  color:#C69749 !important;
   font-weight: 150;
 }
 
 .btn{
-  background-color: #C69749;
+  background-color: #C69749 !important;
 }
 
 .btn:hover {
-  background-color: black;
+  background-color: black !important;
   color: white;
 }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -20,7 +20,7 @@
 
 }
 .nav-link {
-  color: #C69749 ;
+  color: #C69749 !important;
 }
 
 .logo-container{

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -4,7 +4,6 @@ body {
   background-size: cover;
 }
 
-
 .search-form-control {
   position: relative;
 }

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,2 +1,3 @@
 // Import page-specific CSS files here.
 @import "home";
+@import "location";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,7 @@
             <%= link_to "Home", root_path, class: "nav-link" %>
           </li>
           <%# <li class="nav-item"> %>
-            <%# <%= link_to "Messages", "#", class: "nav-link" %> %>
+            <%# <%= link_to "Messages", "#", class: "nav-link" %>
           <%# </li> %>
           <li class="nav-item dropdown">
             <%= image_tag "signup_avatar.jpeg", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>


### PR DESCRIPTION
Apply custom color to form text and nav-link

![signup-page](https://github.com/chrononaut76/rails-airbnboo/assets/23464327/eff2e7dc-37f3-4d22-a7b4-2706e267e892)
